### PR TITLE
Fix trim title inconsistency

### DIFF
--- a/src/main/resources/assets/alexscaves/lang/en_us.json
+++ b/src/main/resources/assets/alexscaves/lang/en_us.json
@@ -591,7 +591,7 @@
   "item.minecraft.lingering_potion.effect.haste": "Lingering Potion of Haste",
   "item.minecraft.lingering_potion.effect.long_haste": "Lingering Potion of Haste",
   "item.minecraft.lingering_potion.effect.strong_haste": "Lingering Potion of Haste",
-  "trim_pattern.alexscaves.polarity": "Polarity",
+  "trim_pattern.alexscaves.polarity": "Polarity Armor Trim",
   "biome.alexscaves.magnetic_caves": "Magnetic Caves",
   "biome.alexscaves.primordial_caves": "Primordial Caves",
   "biome.alexscaves.toxic_caves": "Toxic Caves",


### PR DESCRIPTION
Make polarity armor trim's title consistent with vanilla