### PR TITLE
Fixed Underzealot and Ferrouslime fake entity rendering

### DIFF
--- a/src/main/java/com/github/alexmodguy/alexscaves/client/render/entity/FerrouslimeRenderer.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/client/render/entity/FerrouslimeRenderer.java
@@ -49,8 +49,8 @@ public class FerrouslimeRenderer extends EntityRenderer<FerrouslimeEntity> imple
         }
         float gelSize = entity.getSlimeSize(partialTicks) - 0.2F;
         poseStack.pushPose();
-        if(sepia){
-            renderGel(entity, partialTicks, poseStack, source.getBuffer(ACRenderTypes.getBookWidget(TEXTURE_GEL, true)), gelSize, light);
+        if(sepia || entity.isFakeEntity()){
+            renderGel(entity, partialTicks, poseStack, source.getBuffer(ACRenderTypes.getBookWidget(TEXTURE_GEL, sepia)), gelSize, light);
         }else{
             renderGel(entity, partialTicks, poseStack, source.getBuffer(ACRenderTypes.getGel(TEXTURE_GEL)), gelSize, light);
             renderGelSpikes(entity, partialTicks, poseStack, source.getBuffer(ACRenderTypes.getGelTriangles(TEXTURE_GEL)), gelSize, light);

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/FerrouslimeEntity.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/FerrouslimeEntity.java
@@ -52,6 +52,7 @@ public class FerrouslimeEntity extends Monster {
     private static final EntityDataAccessor<Integer> ATTACK_TICK = SynchedEntityData.defineId(FerrouslimeEntity.class, EntityDataSerializers.INT);
     private int mergeCooldown = 0;
     private int noMoveTime = 0;
+    private boolean fakeEntity = true;
 
     public FerrouslimeEntity(EntityType<? extends Monster> type, Level level) {
         super(type, level);
@@ -97,8 +98,15 @@ public class FerrouslimeEntity extends Monster {
         }
     }
 
+    public boolean isFakeEntity() {
+        return this.fakeEntity;
+    }
+
     public void tick() {
         super.tick();
+        if (this.fakeEntity) {
+            this.fakeEntity = false;
+        }
         this.setYHeadRot(this.getYRot());
         prevMergeProgress = mergeProgress;
         prevAttackProgress = attackProgress;

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/FerrouslimeEntity.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/FerrouslimeEntity.java
@@ -52,7 +52,6 @@ public class FerrouslimeEntity extends Monster {
     private static final EntityDataAccessor<Integer> ATTACK_TICK = SynchedEntityData.defineId(FerrouslimeEntity.class, EntityDataSerializers.INT);
     private int mergeCooldown = 0;
     private int noMoveTime = 0;
-    private boolean fakeEntity = true;
 
     public FerrouslimeEntity(EntityType<? extends Monster> type, Level level) {
         super(type, level);
@@ -99,14 +98,11 @@ public class FerrouslimeEntity extends Monster {
     }
 
     public boolean isFakeEntity() {
-        return this.fakeEntity;
+        return this.firstTick;
     }
 
     public void tick() {
         super.tick();
-        if (this.fakeEntity) {
-            this.fakeEntity = false;
-        }
         this.setYHeadRot(this.getYRot());
         prevMergeProgress = mergeProgress;
         prevAttackProgress = attackProgress;

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/UnderzealotEntity.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/UnderzealotEntity.java
@@ -130,7 +130,7 @@ public class UnderzealotEntity extends Monster implements PackAnimal, IAnimatedE
         prevBuriedProgress = buriedProgress;
         prevCarryingProgress = carryingProgress;
         prevPrayingProgress = prayingProgress;
-        if(buriedProgress == 0.0F && this.isBuried() || buriedProgress == 20.0F && !this.isBuried()){
+        if(!this.isNoAi() && (buriedProgress == 0.0F && this.isBuried() || buriedProgress == 20.0F && !this.isBuried())){
             this.playSound(ACSoundRegistry.UNDERZEALOT_DIG.get());
         }
         if (isBuried() && buriedProgress < 20.0F) {
@@ -317,7 +317,7 @@ public class UnderzealotEntity extends Monster implements PackAnimal, IAnimatedE
     }
 
     public float getBuriedProgress(float partialTick) {
-        return (prevBuriedProgress + (buriedProgress - prevBuriedProgress) * partialTick) * 0.05F;
+        return this.isNoAi() ? 0.0F : (prevBuriedProgress + (buriedProgress - prevBuriedProgress) * partialTick) * 0.05F;
     }
 
     public float getCarryingProgress(float partialTick) {


### PR DESCRIPTION
Currently working on an update for my mod [OpenBlocks Trophies](https://legacy.curseforge.com/minecraft/mc-mods/openblocks-trophies) to add trophy support for this mod and I came across a couple issue mobs. This PR fixes the issues I was having. 
Underzealots were rendering invisible because their dig progress stuff was set to max in their constructor, so I simply added a check for NoAI. This will also prevent the animation from playing if summoned in via commands with no AI as well.
Ferrouslimes were interesting because the gel shader uses GameTime, meaning it bounces around regardless of if the entity is ticking or not. The solution here was to just use the same method book rendering uses if an entity isnt ticking. 