### PR TITLE
fixed tablet nbt typo and handle bad tablets better

### DIFF
--- a/src/main/resources/assets/alexscaves/lang/en_us.json
+++ b/src/main/resources/assets/alexscaves/lang/en_us.json
@@ -546,6 +546,7 @@
   "death.attack.dark_arrow_1.entity": "%s was swarmed by dark magic arrows by %s",
   "alexscaves.container.spelunkery_table": "Spelunkery Table",
   "alexscaves.container.spelunkery_table_translation": "Spelunkery Table Translation",
+  "alexscaves.container.spelunkery_table.bad_tablet": "Cave Tablet has invalid NBT data",
   "alexscaves.container.spelunkery_table.find": "Find:",
   "alexscaves.container.spelunkery_table.attempts": "Attempts Left:",
   "alexscaves.container.spelunkery_table.slot_info_tablet_0": "Place a %s in this slot to begin research...",

--- a/src/main/resources/data/alexscaves/loot_tables/chests/toxic_ruins.json
+++ b/src/main/resources/data/alexscaves/loot_tables/chests/toxic_ruins.json
@@ -14,7 +14,7 @@
           "functions": [
             {
               "function": "set_nbt",
-              "tag": "{CaveBiome:\"alexscaves:toxic_ruins\"}"
+              "tag": "{CaveBiome:\"alexscaves:toxic_caves\"}"
             }
           ]
         },


### PR DESCRIPTION
When adding cave tablets were added to the various structure ruins in 1.0.5, a typo was made in the toxic cave ruins, causing the tablet to become an invalid one and crash the game when used in a spelunkery table. This PR corrects the NBT data on those tablets.

This PR also adds better error handling for invalid tablets. Instead of crashing since the table attempts to modify an immutable list later down the line, it will instead print an error message that the tablet is invalid and will print the bad nbt on the item. This simply prints all cave tablet NBT on the screen to allow for easier debugging. 

![2023-10-25_02 43 46](https://github.com/AlexModGuy/AlexsCaves/assets/67468252/e4dbf1e9-4171-44d1-8c6a-db8584350c58)
![2023-10-25_02 44 53](https://github.com/AlexModGuy/AlexsCaves/assets/67468252/eaf5d7cf-3508-4a5c-aa8d-c69904c37f20)

While working on a fix I also fixed an issue where words wouldn't get randomized again if you switched the currently slotted cave tablet with one held by your mouse, meaning the words to find wouldn't match with the biome's theme. 

Please let me know if this isnt to your liking, im happy to change things as needed!