### PR TITLE
Tag Primordial Caves as `forge:no_default_monsters` biome tag

### DIFF
--- a/src/main/resources/data/forge/tags/worldgen/biome/no_default_monsters.json
+++ b/src/main/resources/data/forge/tags/worldgen/biome/no_default_monsters.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "alexscaves:primordial_caves"
+  ]
+}


### PR DESCRIPTION
This will make it so that other mods know they should not add monsters to Primordial Caves. Especially because if they do, the other mod's monsters will spawn out of control.

With this tag in place, it makes it easier for other mods to avoid adding to Primordial Caves. Terralith is now using this biome tag as well.