### PR TITLE
Properly render new mobs in 1.1.0 as fake entities

### DIFF
--- a/src/main/java/com/github/alexmodguy/alexscaves/client/model/SauropodBaseModel.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/client/model/SauropodBaseModel.java
@@ -428,7 +428,7 @@ public abstract class SauropodBaseModel<T extends SauropodBaseEntity> extends Ad
     }
 
     private void positionNeckAndTail(SauropodBaseEntity entity, float netHeadYaw, float headPitch, float partialTicks) {
-        if (!straighten) {
+        if (!straighten && !entity.isFakeEntity()) {
             float neckPart1Pitch = (float) Math.toRadians(entity.neckPart1.calculateAnimationAngle(partialTicks, true)) * 0.5F;
             float neckPart2Pitch = (float) Math.toRadians(entity.neckPart2.calculateAnimationAngle(partialTicks, true)) * 0.5F;
             float neckPart3Pitch = (float) Math.toRadians(entity.neckPart3.calculateAnimationAngle(partialTicks, true)) * 0.5F;

--- a/src/main/java/com/github/alexmodguy/alexscaves/client/model/TremorzillaModel.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/client/model/TremorzillaModel.java
@@ -526,7 +526,7 @@ public class TremorzillaModel extends AdvancedEntityModel<TremorzillaEntity> {
         float headPitchAmount = headPitch / 57.295776F * (1F - burnProgress) * standProgress;
         Vec3 burnPos = entity.getClientBeamEndPosition(partialTicks);
         articulateLegs(entity.legSolver, partialTicks, groundProgress * (1F - danceProgress) * standProgress);
-        if(!straighten){
+        if (!straighten && !entity.isFakeEntity()) {
             positionTail(entity, partialTicks);
         }
         if (buryEggsAmount > 0.0F) {

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/SauropodBaseEntity.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/SauropodBaseEntity.java
@@ -128,6 +128,10 @@ public abstract class SauropodBaseEntity extends DinosaurEntity implements Shake
         return new AdvancedPathNavigate(this, level);
     }
 
+    public boolean isFakeEntity() {
+        return this.firstTick;
+    }
+
     @Override
     public void tick() {
         super.tick();

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/TremorzillaEntity.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/TremorzillaEntity.java
@@ -224,6 +224,10 @@ public class TremorzillaEntity extends DinosaurEntity implements KeybindUsingMou
         this.targetSelector.addGoal(3, new OwnerHurtTargetGoal(this));
     }
 
+    public boolean isFakeEntity() {
+        return this.firstTick;
+    }
+
     public void tick() {
         super.tick();
         AnimationHandler.INSTANCE.updateAnimations(this);


### PR DESCRIPTION
Similar to #91, this fixes entity rendering for the Tremorzilla, Luxtructosaurus, and Atlatitan when rendering as a fake entity. This is so the mobs look correct when displayed through mods like JER or my mod OpenBlocks Trophies. 

I would really appreciate if these model flag solutions for rendering mobs like this would no longer be a thing as most mods don't want to special case them and the models look really bad without them enabled, but I'll continue pushing fixes like this as I find them without any complaints