### PR TITLE
Better underground cabin exclusion biome checking

### DIFF
--- a/src/main/java/com/github/alexmodguy/alexscaves/server/level/structure/UndergroundCabinStructure.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/level/structure/UndergroundCabinStructure.java
@@ -40,9 +40,6 @@ public class UndergroundCabinStructure extends Structure {
         int y = context.chunkGenerator().getBaseHeight(context.chunkPos().getMinBlockX(), context.chunkPos().getMinBlockZ(), Heightmap.Types.OCEAN_FLOOR_WG, levelHeight, context.randomState()) - 20;
         int maxHeight = y - 14 - context.random().nextInt(15);
         BlockPos blockpos = new BlockPos(context.chunkPos().getMinBlockX(), maxHeight, context.chunkPos().getMinBlockZ());
-        if(context.biomeSource().getNoiseBiome(blockpos.getX(), blockpos.getY(), blockpos.getZ(), context.randomState().sampler()).is(ACTagRegistry.HAS_NO_UNDERGROUND_CABINS)){
-            return Optional.empty();
-        }
         ResourceLocation res = Util.getRandom(CABIN_NBT, context.random());
         return Optional.of(new GenerationStub(blockpos, (piecesBuilder -> piecesBuilder.addPiece(new UndergroundCabinStructurePiece(context.structureTemplateManager(), res, blockpos, rotation)))));
     }

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/misc/ACTagRegistry.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/misc/ACTagRegistry.java
@@ -74,7 +74,6 @@ public class ACTagRegistry {
     public static final TagKey<EntityType<?>> RESISTS_RADIATION = registerEntityTag("resists_radiation");
     public static final TagKey<EntityType<?>> SEAFLOOR_DENIZENS = registerEntityTag("seafloor_denizens");
     public static final TagKey<EntityType<?>> GLOWING_ENTITIES = registerEntityTag("glowing_entities");
-    public static final TagKey<Biome> HAS_NO_UNDERGROUND_CABINS = registerBiomeTag("has_no_underground_cabins");
     public static final TagKey<Biome> CAVE_MAP_BORDER_ON = registerBiomeTag("cave_map_border_on");
     public static final TagKey<Biome> TRENCH_IGNORES_STONE_IN = registerBiomeTag("trench_ignores_stone_in");
     public static final TagKey<Biome> OVERRIDE_ALL_VANILLA_MUSIC_IN = registerBiomeTag("override_all_vanilla_music_in");

--- a/src/main/resources/data/alexscaves/worldgen/structure/underground_cabin.json
+++ b/src/main/resources/data/alexscaves/worldgen/structure/underground_cabin.json
@@ -1,6 +1,16 @@
 {
   "type": "alexscaves:underground_cabin",
-  "biomes": "#alexscaves:has_underground_cabins",
+  "biomes": {
+    "type": "forge:and",
+    "values":
+    [
+      "#alexscaves:has_underground_cabins",
+      {
+        "type": "forge:not",
+        "value": "#alexscaves:has_no_underground_cabins"
+      }
+    ]
+  },
   "step": "underground_structures",
   "start_height": {
     "absolute": 0


### PR DESCRIPTION
By using Forge's holderset system, you can remove the in-code biome checking and just keep it in the structure json file. Cleaner imo and makes a good example for players/packmakers to use for modifying other structures to be excluded from certain biomes. Tested and verified this works so should be good.