### PR TITLE
Add config option for purple soda right click bottling

### DIFF
--- a/src/main/java/com/github/alexmodguy/alexscaves/server/config/ACServerConfig.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/config/ACServerConfig.java
@@ -38,6 +38,7 @@ public class ACServerConfig {
     public final ForgeConfigSpec.DoubleValue abyssalTabletLootChance;
     public final ForgeConfigSpec.DoubleValue forlornTabletLootChance;
     public final ForgeConfigSpec.DoubleValue candyTabletLootChance;
+    public final ForgeConfigSpec.BooleanValue purpleSodaRightClickBottling;
     public final ForgeConfigSpec.DoubleValue cabinMapLootChance;
     public final ForgeConfigSpec.BooleanValue cartographersSellCabinMaps;
     public final ForgeConfigSpec.BooleanValue wanderingTradersSellCabinMaps;
@@ -82,6 +83,7 @@ public class ACServerConfig {
         totemOfPossessionPlayers = builder.comment("Whether the Totem of Possession can be applied to players.").translation("totem_of_possession_works_on_players").define("totem_of_possession_works_on_players", true);
         darknessCloakChargeTime = builder.comment("The amount of time (in ticks) it takes to charge up the Cloak of Darkness ability.").translation("darkness_cloak_charge_time").defineInRange("darkness_cloak_charge_time", 1000, 20, Integer.MAX_VALUE);
         darknessCloakFlightTime = builder.comment("The amount of time (in ticks) that players can fly with the Cloak of Darkness ability.").translation("darkness_cloak_fly_time").defineInRange("darkness_cloak_fly_time", 200, 20, Integer.MAX_VALUE);
+        purpleSodaRightClickBottling = builder.comment("Whether purple soda can be bottled with a right click of a glass bottle.").translation("purple_soda_right_click_bottling").define("purple_soda_right_click_bottling", true);
         builder.pop();
         builder.push("potion-behavior");
         sugarRushSlowsTime = builder.comment("Whether the Sugar Rush changes the tick rate of the game in the area of affected players.").translation("sugar_rush_slows_time").define("sugar_rush_slows_time", true);

--- a/src/main/java/com/github/alexmodguy/alexscaves/server/event/CommonEvents.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/event/CommonEvents.java
@@ -438,7 +438,7 @@ public class CommonEvents {
     @SubscribeEvent
     public void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
         Player player = event.getEntity();
-        if (event.getItemStack().getItem() == Items.GLASS_BOTTLE) {
+        if (event.getItemStack().getItem() == Items.GLASS_BOTTLE && AlexsCaves.COMMON_CONFIG.purpleSodaRightClickBottling.get()) {
             HitResult raytraceresult = getPlayerPOVHitResult(event.getLevel(), player, ClipContext.Fluid.SOURCE_ONLY);
             if (raytraceresult.getType() == HitResult.Type.BLOCK) {
                 BlockPos blockpos = ((BlockHitResult) raytraceresult).getBlockPos();


### PR DESCRIPTION
Hello Dr. Alexander Caverns,

Alex's Mobs has an option for disabling lava bottling (see [alexsmobs/event/ServerEvents.java#L349](https://github.com/AlexModGuy/AlexsMobs/blob/0d7bea8f643bff978ff2b9e4690f3c2a1a514266/src/main/java/com/github/alexthe666/alexsmobs/event/ServerEvents.java#L349), and I think purple soda should have the same. This is convenient for mod pack creators that wants to use purple soda as a limited resource.