### PR TITLE
Prevent Create from treating jelly beans like potions

### DIFF
--- a/src/main/resources/data/create/tags/items/not_potion.json
+++ b/src/main/resources/data/create/tags/items/not_potion.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "alexscaves:jelly_bean"
+  ]
+}


### PR DESCRIPTION
See https://github.com/Creators-of-Create/Create/pull/9147 for more context. This tag prevents Create from treating jelly beans like potions, which I assume is not intentional. This tag is not in a release version of Create yet so you can wait on merging here, or not.