### PR TITLE
Fixed #1404

### DIFF
--- a/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/GummyBearEntity.java
+++ b/src/main/java/com/github/alexmodguy/alexscaves/server/entity/living/GummyBearEntity.java
@@ -181,6 +181,7 @@ public class GummyBearEntity extends Animal implements IDancesToJukebox, IAnimat
         compound.putInt("GummyColor", this.getGummyColor().ordinal());
         if (digestingEffect != null) {
             compound.putString("DigestingEffect", digestingEffect.toString());
+            compound.putInt("JellyBeansToMake", this.jellybeansToMake);
         }
         compound.putBoolean("BearSleeping", this.isBearSleeping());
         compound.putBoolean("BearSitting", this.isSitting());
@@ -192,7 +193,9 @@ public class GummyBearEntity extends Animal implements IDancesToJukebox, IAnimat
         super.readAdditionalSaveData(compound);
         this.setGummyColor(GummyColors.fromOrdinal(compound.getInt("GummyColor")));
         if (compound.contains("DigestingEffect")) {
-            digestingEffect = ResourceLocation.parse(compound.getString("DigestingEffect"));
+            this.digestEffect(ForgeRegistries.POTIONS.getValue(ResourceLocation.parse(compound.getString("DigestingEffect"))));
+            this.setDigesting(digestingEffect != null);
+            this.jellybeansToMake = compound.getInt("JellyBeansToMake");
         }
         this.setBearSleeping(compound.getBoolean("BearSleeping"));
         this.setStanding(compound.getBoolean("BearSitting"));


### PR DESCRIPTION
digestingEffect was incorrectly being set to null during tick because DIGESTING wasn't set on load. Referenced mobInteract() to correctly setup the mob on load.

jellybeansToMake is now saved to fix a related issue where Gummy Bears always dropped the default value of 5 after being unloaded. Gummy Bears correctly produce the 3-4 Jelly Beans as they did previously.